### PR TITLE
fix: do not modify iter during List.map and Map.map (#1649)

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -519,6 +519,14 @@ describe('List', () => {
     expect(r).toBe(v);
   });
 
+  it('ensures iter is unmodified', () => {
+    const v = List.of(1, 2, 3);
+    const r = v.map((value, index, iter) => {
+      return iter.get(index - 1);
+    });
+    expect(r.toArray()).toEqual([3, 1, 2]);
+  });
+
   it('filters values', () => {
     const v = List.of('a', 'b', 'c', 'd', 'e', 'f');
     const r = v.filter((value, index) => index % 2 === 1);

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -261,6 +261,12 @@ describe('Map', () => {
     expect(r).toBe(m);
   });
 
+  it('ensures iter is unmodified', () => {
+    const m = Map({ a: 1, b: 1 });
+    const r = m.map((value, key, iter) => 2 * iter.get(key));
+    expect(r.toObject()).toEqual({ a: 2, b: 2 });
+  });
+
   it('filters values', () => {
     const m = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     const r = m.filter(value => value % 2 === 1);

--- a/src/List.js
+++ b/src/List.js
@@ -176,7 +176,7 @@ export class List extends IndexedCollection {
   map(mapper, context) {
     return this.withMutations(list => {
       for (let i = 0; i < this.size; i++) {
-        list.set(i, mapper.call(context, list.get(i), i, list));
+        list.set(i, mapper.call(context, list.get(i), i, this));
       }
     });
   }

--- a/src/Map.js
+++ b/src/Map.js
@@ -128,7 +128,7 @@ export class Map extends KeyedCollection {
   map(mapper, context) {
     return this.withMutations(map => {
       map.forEach((value, key) => {
-        map.set(key, mapper.call(context, value, key, map));
+        map.set(key, mapper.call(context, value, key, this));
       });
     });
   }


### PR DESCRIPTION
Fixes [#1757](https://github.com/immutable-js/immutable-js/issues/1757) and [#1649](https://github.com/immutable-js/immutable-js/issues/1649) in original immutable-js repo. See this long outstanding PR for more details: [https://github.com/immutable-js/immutable-js/pull/1707](https://github.com/immutable-js/immutable-js/pull/1707)