### PR TITLE
docs: Fix simple typo, interpretted -> interpreted

### DIFF
--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -274,7 +274,7 @@ stringToNumber = Map(List([['a', 1]]))
 stringToNumber = Map([['a', 'b']])
 // $ExpectError -- this is actually a Map<string, string>
 stringToNumber = Map(List([['a', 'a']]))
-// $FlowFixMe - This is Iterable<Iterable<string>>, ideally it could be interpretted as Iterable<[string, string]>
+// $FlowFixMe - This is Iterable<Iterable<string>>, ideally it could be interpreted as Iterable<[string, string]>
 stringToNumber = Map(List([List(['a', 'a'])]))
 
 stringOrNumberToNumberOrString = Map({'a': 'a'}).set('b', 1).set(2, 'c')


### PR DESCRIPTION
There is a small typo in type-definitions/tests/immutable-flow.js.

Should read `interpreted` rather than `interpretted`.