### PR TITLE
Fix returning a Record in merge() when Record is empty

### DIFF
--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -125,3 +125,9 @@ describe('Issue #1643', () => {
     });
   });
 });
+
+describe('Issue #1785', () => {
+  const emptyRecord = Record({})();
+
+  expect(emptyRecord.merge({ id: 1 })).toBe(emptyRecord);
+});

--- a/src/Record.js
+++ b/src/Record.js
@@ -77,6 +77,7 @@ export class Record {
           l.set(this._indices[k], v === this._defaultValues[k] ? undefined : v);
         });
       });
+      return this;
     };
 
     const RecordTypePrototype = (RecordType.prototype = Object.create(


### PR DESCRIPTION
Resolves https://github.com/immutable-js/immutable-js/issues/1785.

I'm not absolutely sure this is the correct fix. It seems almost too simple.