### PR TITLE
Fix missing term in doc generation

### DIFF
--- a/pages/lib/TypeKind.js
+++ b/pages/lib/TypeKind.js
@@ -21,13 +21,14 @@ var TypeKind = {
 
   This: 10,
   Undefined: 11,
-  Union: 12,
-  Intersection: 13,
-  Tuple: 14,
-  Indexed: 15,
-  Operator: 16,
+  Null: 12,
+  Union: 13,
+  Intersection: 14,
+  Tuple: 15,
+  Indexed: 16,
+  Operator: 17,
 
-  Unknown: 17,
+  Unknown: 18,
 };
 
 module.exports = TypeKind;

--- a/pages/lib/genTypeDefData.js
+++ b/pages/lib/genTypeDefData.js
@@ -273,7 +273,7 @@ function DocVisitor(source) {
     switch (node.kind) {
       case ts.SyntaxKind.NeverKeyword:
         return {
-          k: TypeKind.NeverKeyword,
+          k: TypeKind.Never,
         };
       case ts.SyntaxKind.AnyKeyword:
         return {
@@ -282,6 +282,10 @@ function DocVisitor(source) {
       case ts.SyntaxKind.UnknownKeyword:
         return {
           k: TypeKind.Unknown,
+        };
+      case ts.SyntaxKind.NullKeyword:
+        return {
+          k: TypeKind.Null,
         };
       case ts.SyntaxKind.ThisType:
         return {

--- a/pages/src/docs/src/Defs.js
+++ b/pages/src/docs/src/Defs.js
@@ -97,6 +97,8 @@ var TypeDef = React.createClass({
         return this.wrap('primitive', 'any');
       case TypeKind.This:
         return this.wrap('primitive', 'this');
+      case TypeKind.Null:
+        return this.wrap('primitive', 'null');
       case TypeKind.Undefined:
         return this.wrap('primitive', 'undefined');
       case TypeKind.Boolean:


### PR DESCRIPTION
In my other PR https://github.com/mcclure/immutable-js/tree/doc-null the tests are failing.

In conversation with @Methuselah96 in Slack, we concluded the problem was a missing term in this switch https://github.com/immutable-js-oss/immutable-js/blob/master/pages/lib/genTypeDefData.js#L273

I have fixed the term in the switch, and a similar problem with the `never` keyword. However, it still fails, just a little later.

Here is the failure I see (Note: I added a `console.log(node)` to the first line of the `parseParam` function)

```
<ref *2> NodeObject {
  pos: 24332,
  end: 24333,
  flags: 4194304,
  transformFlags: undefined,
  parent: <ref *1> NodeObject {
    pos: 24331,
    end: 24337,
    flags: 4194304,
    transformFlags: undefined,
    parent: NodeObject {
      pos: 24324,
      end: 24337,
      flags: 4194304,
      transformFlags: undefined,
      parent: [NodeObject],
      kind: 149,
      decorators: undefined,
      modifiers: undefined,
      dotDotDotToken: undefined,
      name: [IdentifierObject],
      questionToken: undefined,
      type: [Circular *1],
      initializer: undefined
    },
    kind: 163,
    typeParameters: undefined,
    parameters: [ [Circular *2], pos: 24332, end: 24333 ],
    type: NodeObject {
      pos: 24336,
      end: 24337,
      flags: 4194304,
      transformFlags: undefined,
      parent: [Circular *1],
      kind: 162,
      typeName: [IdentifierObject]
    }
  },
  kind: 149,
  decorators: undefined,
  modifiers: undefined,
  dotDotDotToken: undefined,
  name: IdentifierObject {
    pos: 24332,
    end: 24333,
    flags: 4194304,
    parent: [Circular *2],
    escapedText: 'T'
  },
  questionToken: undefined,
  type: undefined,
  initializer: undefined
}
[01:01:00] 'typedefs' errored after 919 ms
[01:01:00] TypeError: Cannot read property 'kind' of undefined
    at parseType (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:273:18)
    at parseParam (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:432:13)
    at /Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:377:44
    at Array.map (<anonymous>)
    at parseType (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:377:35)
    at parseParam (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:432:13)
    at /Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:260:55
    at Array.map (<anonymous>)
    at parseCallSignature (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:260:46)
    at visitFunctionDeclaration (/Users/mcc/work/gh/other/immutable-js/pages/lib/genTypeDefData.js:119:27)
[01:01:00] 'default' errored after 932 ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "build:pages" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It seems `type` is, indeed, undefined, but I don't understand why. It looks like the object with the undefined type is a template `T`. I'm not really sure what this code thinks it is trying to do :(