### PR TITLE
Fix #159: support isPlainObj in IE11 and constructor.name props

### DIFF
--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,0 +1,58 @@
+/* global document */
+const { List, isPlainObject } = require('../');
+
+describe('Utils', () => {
+  describe('isPlainObj()', function testFunc() {
+    const nonPlainCases = [
+      ['Host object', document.createElement('div')],
+      ['bool primitive false', false],
+      ['bool primitive true', true],
+      ['falsy undefined', undefined],
+      ['falsy null', null],
+      ['Simple function', function () {}],
+      [
+        'Instance of other object',
+        (function () {
+          function Foo() {}
+          return new Foo();
+        })(),
+      ],
+      ['Number primitive ', 5],
+      ['String primitive ', 'P'],
+      ['Number Object', Number(6)],
+      ['Immutable.List', new List()],
+      ['simple array', ['one']],
+      ['Error', Error],
+      ['Internal namespaces', Math],
+      ['Arguments', arguments],
+    ];
+    const plainCases = [
+      ['literal Object', {}],
+      ['new Object', new Object()], // eslint-disable-line no-new-object
+      ['Object.create(null)', Object.create(null)],
+      ['nested object', { one: { prop: 'two' } }],
+      ['constructor prop', { constructor: 'prop' }], // shadows an object's constructor
+      ['constructor.name', { constructor: { name: 'two' } }], // shadows an object's constructor.name
+      [
+        'Fake toString',
+        {
+          toString: function () {
+            return '[object Object]';
+          },
+        },
+      ],
+    ];
+
+    nonPlainCases.forEach(([name, value]) => {
+      it(`${name} returns false`, () => {
+        expect(isPlainObject(value)).toBe(false);
+      });
+    });
+
+    plainCases.forEach(([name, value]) => {
+      it(`${name} returns true`, () => {
+        expect(isPlainObject(value)).toBe(true);
+      });
+    });
+  });
+});

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -18,6 +18,8 @@ import { Repeat } from './Repeat';
 import { is } from './is';
 import { fromJS } from './fromJS';
 
+import isPlainObject from './utils/isPlainObj';
+
 // Functional predicates
 import { isImmutable } from './predicates/isImmutable';
 import { isCollection } from './predicates/isCollection';
@@ -83,6 +85,7 @@ export default {
   isAssociative: isAssociative,
   isOrdered: isOrdered,
   isValueObject: isValueObject,
+  isPlainObject: isPlainObject,
   isSeq: isSeq,
   isList: isList,
   isMap: isMap,
@@ -134,6 +137,7 @@ export {
   isIndexed,
   isAssociative,
   isOrdered,
+  isPlainObject,
   isValueObject,
   isSeq,
   isList,

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -5,10 +5,29 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export default function isPlainObj(value) {
-  return (
-    value &&
-    (typeof value.constructor !== 'function' ||
-      value.constructor.name === 'Object')
-  );
+const toString = Object.prototype.toString;
+
+export default function isPlainObject(value) {
+  // The base prototype's toString deals with Argument objects and native namespaces like Math
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    toString.call(value) !== '[object Object]'
+  ) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  if (proto === null) {
+    return true;
+  }
+
+  // Iteratively going up the prototype chain is needed for cross-realm environments (differing contexts, iframes, etc)
+  let parentProto = proto;
+  let nextProto = Object.getPrototypeOf(proto);
+  while (nextProto !== null) {
+    parentProto = nextProto;
+    nextProto = Object.getPrototypeOf(parentProto);
+  }
+  return parentProto === proto;
 }


### PR DESCRIPTION
Deals with IE9-IE11 and correctly evaluates `{ constructor: { name: 'bamboozled' }}`
I am not that happy with exporting `isPlainObject`, if you see a better alternative to test it, be my guest