### PR TITLE
Revert "Throw TypeError on merge() if types are incompatible (#215)"

### DIFF
--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -8,15 +8,7 @@
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;
-import {
-  fromJS,
-  List,
-  OrderedMap,
-  OrderedSet,
-  Record,
-  Seq,
-  Set,
-} from 'immutable';
+import { List, OrderedMap, OrderedSet, Record, Seq, Set } from 'immutable';
 
 describe('Issue #1175', () => {
   it('invalid hashCode() response should not infinitly recurse', () => {
@@ -138,36 +130,4 @@ describe('Issue #1785', () => {
   const emptyRecord = Record({})();
 
   expect(emptyRecord.merge({ id: 1 })).toBe(emptyRecord);
-});
-
-describe('Issue #1475', () => {
-  it("complex case should throw TypeError on mergeDeep when types aren't compatible", () => {
-    const a = fromJS({
-      ch: [
-        {
-          code: 8,
-        },
-      ],
-    });
-    const b = fromJS({
-      ch: {
-        code: 8,
-      },
-    });
-    expect(() => {
-      a.mergeDeep(b);
-    }).toThrowError(TypeError);
-  });
-
-  it("simple case should throw TypeError on mergeDeep when types aren't compatible", () => {
-    const a = fromJS({
-      ch: [],
-    });
-    const b = fromJS({
-      ch: { code: 8 },
-    });
-    expect(() => {
-      a.mergeDeep(b);
-    }).toThrowError(TypeError);
-  });
 });

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -9,6 +9,7 @@
 
 import {
   fromJS,
+  is,
   List,
   Map,
   merge,
@@ -281,29 +282,5 @@ describe('merge', () => {
   it('merges records with a size property set to 0', () => {
     const Sizable = Record({ size: 0 });
     expect(Sizable().merge({ size: 123 }).size).toBe(123);
-  });
-
-  describe('throws TypeError when merging', () => {
-    const incompatibleMerges = [
-      ['Map', 'List', Map({ foo: 'bar' }), List(['bar'])],
-      ['Map', 'array', Map({ foo: 'bar' }), ['bar']],
-      ['object', 'List', { foo: 'bar' }, List(['bar'])],
-      ['object', 'array', { foo: 'bar' }, ['bar']],
-    ];
-
-    incompatibleMerges.forEach(
-      ([firstName, secondName, firstValue, secondValue]) => {
-        it(`${firstName} and ${secondName}`, () => {
-          expect(() => {
-            merge(firstValue, secondValue);
-          }).toThrowError(TypeError);
-        });
-        it(`${secondName} and ${firstName}`, () => {
-          expect(() => {
-            merge(secondValue, firstValue);
-          }).toThrowError(TypeError);
-        });
-      }
-    );
   });
 });

--- a/src/List.js
+++ b/src/List.js
@@ -18,7 +18,6 @@ import {
   resolveBegin,
   resolveEnd,
 } from './TrieUtils';
-import { isKeyed } from './predicates/isKeyed';
 import { IS_LIST_SYMBOL, isList } from './predicates/isList';
 import { IndexedCollection } from './Collection';
 import { hasIterator, Iterator, iteratorValue, iteratorDone } from './Iterator';
@@ -33,7 +32,6 @@ import { asMutable } from './methods/asMutable';
 import { asImmutable } from './methods/asImmutable';
 import { wasAltered } from './methods/wasAltered';
 import assertNotInfinite from './utils/assertNotInfinite';
-import isPlainObject from './utils/isPlainObj';
 
 export class List extends IndexedCollection {
   // @pragma Construction
@@ -150,18 +148,10 @@ export class List extends IndexedCollection {
     const seqs = [];
     for (let i = 0; i < arguments.length; i++) {
       const argument = arguments[i];
-      const argumentHasIterator =
-        typeof argument !== 'string' && hasIterator(argument);
-      if (
-        isKeyed(argument) ||
-        (!argumentHasIterator && isPlainObject(argument))
-      ) {
-        throw new TypeError(
-          'Expected iterable, non-keyed argument: ' + argument
-        );
-      }
       const seq = IndexedCollection(
-        argumentHasIterator ? argument : [argument]
+        typeof argument !== 'string' && hasIterator(argument)
+          ? argument
+          : [argument]
       );
       if (seq.size !== 0) {
         seqs.push(seq);

--- a/src/functional/merge.js
+++ b/src/functional/merge.js
@@ -6,12 +6,9 @@
  */
 
 import { isImmutable } from '../predicates/isImmutable';
-import { isIndexed } from '../predicates/isIndexed';
-import { isKeyed } from '../predicates/isKeyed';
 import { IndexedCollection, KeyedCollection } from '../Collection';
 import hasOwnProperty from '../utils/hasOwnProperty';
 import isDataStructure from '../utils/isDataStructure';
-import isPlainObject from '../utils/isPlainObj';
 import shallowCopy from '../utils/shallowCopy';
 
 export function merge(collection, ...sources) {
@@ -48,7 +45,6 @@ export function mergeWithSources(collection, sources, merger) {
       : collection.concat(...sources);
   }
   const isArray = Array.isArray(collection);
-  const isObject = !isArray;
   let merged = collection;
   const Collection = isArray ? IndexedCollection : KeyedCollection;
   const mergeItem = isArray
@@ -72,14 +68,7 @@ export function mergeWithSources(collection, sources, merger) {
         }
       };
   for (let i = 0; i < sources.length; i++) {
-    const source = sources[i];
-    if (
-      (isArray && (isPlainObject(source) || isKeyed(source))) ||
-      (isObject && (Array.isArray(source) || isIndexed(source)))
-    ) {
-      throw new TypeError('Expected non-keyed argument: ' + source);
-    }
-    Collection(source).forEach(mergeItem);
+    Collection(sources[i]).forEach(mergeItem);
   }
   return merged;
 }


### PR DESCRIPTION
Due to the conversation in https://github.com/immutable-js-oss/immutable-js/pull/215, I am reverting that PR so we can work on an alternative solution.